### PR TITLE
🔀 :: (#62) Feature - write detail page viewmodel logic

### DIFF
--- a/domain/src/main/java/com/mpersand/domain/usecase/equipment/GetEquipmentInfoUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/equipment/GetEquipmentInfoUseCase.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class GetEquipmentInfoUseCase @Inject constructor(
     private val equipmentRepository: EquipmentRepository
 ) {
-    suspend operator fun invoke(productNumber: String) = equipmentRepository.getEquipmentInfo(productNumber)
+    suspend operator fun invoke(productNumber: String) = kotlin.runCatching { equipmentRepository.getEquipmentInfo(productNumber) }
 }

--- a/domain/src/main/java/com/mpersand/domain/usecase/order/PostRentalRequestUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/order/PostRentalRequestUseCase.kt
@@ -7,5 +7,5 @@ import javax.inject.Inject
 class PostRentalRequestUseCase @Inject constructor(
     private val orderRepository: OrderRepository
 ) {
-    suspend operator fun invoke(orderRequest: OrderRequestModel) = orderRepository.postRentalRequest(orderRequest)
+    suspend operator fun invoke(orderRequest: OrderRequestModel) = kotlin.runCatching { orderRepository.postRentalRequest(orderRequest) }
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,10 +29,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.mpersand.presentation.R
+import com.mpersand.presentation.viewmodel.DetailViewModel
 
 @Composable
-fun DetailScreen(modifier: Modifier = Modifier) {
+fun DetailScreen(
+    modifier: Modifier = Modifier,
+    productNumber: String?,
+    viewModel: DetailViewModel = hiltViewModel()
+) {
+    LaunchedEffect(Unit) {
+        viewModel.getEquipmentInfo(checkNotNull(productNumber))
+    }
+
     var imageUri by remember { mutableStateOf<Uri?>(null) }
     var showDialog by remember { mutableStateOf(false) }
 
@@ -99,5 +110,5 @@ fun DetailScreen(modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun preview() {
-    DetailScreen()
+//    DetailScreen()
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/detail/navigation/DetailNavigation.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/detail/navigation/DetailNavigation.kt
@@ -1,0 +1,18 @@
+package com.mpersand.presentation.view.detail.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.mpersand.presentation.view.detail.DetailScreen
+
+const val detailRoute = "detail_route"
+
+fun NavController.navigateToDetail(productNumber: String) {
+    this.navigate("$detailRoute/$productNumber")
+}
+
+fun NavGraphBuilder.detailScreen() {
+    composable("$detailRoute/{productNumber}") { navBackStackEntry ->
+        DetailScreen(productNumber = navBackStackEntry.arguments?.getString("productNumber"))
+    }
+}

--- a/presentation/src/main/java/com/mpersand/presentation/viewmodel/DetailViewModel.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/viewmodel/DetailViewModel.kt
@@ -1,0 +1,41 @@
+package com.mpersand.presentation.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.mpersand.domain.model.order.request.OrderRequestModel
+import com.mpersand.domain.usecase.equipment.GetEquipmentInfoUseCase
+import com.mpersand.domain.usecase.order.PostRentalRequestUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DetailViewModel @Inject constructor(
+    private val getEquipmentInfoUseCase: GetEquipmentInfoUseCase,
+    private val postRentalRequestUseCase: PostRentalRequestUseCase
+): ViewModel() {
+    fun getEquipmentInfo(productNumber: String) {
+        viewModelScope.launch {
+            getEquipmentInfoUseCase(productNumber)
+                .onSuccess {
+                    Log.d("Success" , "getEquipmentInfo: $it")
+                }
+                .onFailure {
+                    Log.d("Failure " , "getEquipmentInfo: ${it.message}")
+                }
+        }
+    }
+
+    fun postRentalRequest(orderRequest: OrderRequestModel) {
+        viewModelScope.launch {
+            postRentalRequestUseCase(orderRequest)
+                .onSuccess {
+                    Log.d("Success", "postRentalRequest: $it")
+                }
+                .onFailure {
+                    Log.d("Failure", "postRentalRequest: ${it.message}")
+                }
+        }
+    }
+}


### PR DESCRIPTION
### 개요
- detail page에 필요한 viewmodel 로직 구현

### 작업내용
- runCatching 추가
- viewmodel 생성
- navigation 구현 + productNumber 가져오기
- LaunchedEffect를 사용하여 view에 접근 시 한 번만 상세정보 가져오기

### 기타사항 (선택)
- 나중에 UiState를 만들고 실제 데이터로 구현한 후에 연결할 듯 합니다
