### PR TITLE
🔀 :: (#95) Feature - search result list navigation logic

### DIFF
--- a/app/src/main/java/com/mpersand/gkr_android/GKRAdminNavHost.kt
+++ b/app/src/main/java/com/mpersand/gkr_android/GKRAdminNavHost.kt
@@ -38,7 +38,8 @@ fun GKRNavHost(
         detailScreen()
 
         searchScreen(
-            navigateToMain = { navController.navigateToMain() }
+            navigateToMain = { navController.navigateToMain() },
+            navigateToDetail = { navController.navigateToDetail(it) }
         )
     }
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.DrawerValue
@@ -37,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
@@ -240,7 +242,9 @@ fun ModalDrawerScreen(
                 modifier = modifier.padding(horizontal = 15.dp)
             ) {
                 Image(
-                    modifier = modifier.size(30.dp, 30.dp),
+                    modifier = modifier
+                        .size(30.dp, 30.dp)
+                        .clip(CircleShape),
                     painter = rememberAsyncImagePainter(userInfo.profileUrl),
                     contentDescription = "image",
                     contentScale = ContentScale.Crop

--- a/presentation/src/main/java/com/mpersand/presentation/view/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/search/SearchScreen.kt
@@ -47,7 +47,8 @@ import com.mpersand.presentation.viewmodel.SearchViewModel
 @Composable
 fun SearchScreen(
     searchViewModel: SearchViewModel = hiltViewModel(),
-    navigateToMain: () -> Unit
+    navigateToMain: () -> Unit,
+    navigateToDetail: (productNumber: String) -> Unit
 ) {
     val textChange = remember { mutableStateOf(false) }
     val isTextChanged = remember { mutableStateOf(false) }
@@ -83,7 +84,8 @@ fun SearchScreen(
         if (!textChange.value && !isTextChanged.value && textState.value.isNotEmpty())
             SearchResultView(
                 text = textState.value,
-                searchViewModel = searchViewModel
+                searchViewModel = searchViewModel,
+                navigateToDetail = navigateToDetail
             )
     }
 }
@@ -170,7 +172,8 @@ fun SearchHistoryView(textState: MutableState<String>) {
 @Composable
 fun SearchResultView(
     text: String,
-    searchViewModel: SearchViewModel
+    searchViewModel: SearchViewModel,
+    navigateToDetail: (productNumber: String) -> Unit
 ) {
     searchViewModel.searchEquipment(text)
     val searchResult by searchViewModel.equipmentFilter.observeAsState()
@@ -194,7 +197,10 @@ fun SearchResultView(
                 verticalArrangement = Arrangement.spacedBy(5.dp)
             ) {
                 items(state.data!!) {
-                    SearchResultItem(data = it)
+                    SearchResultItem(
+                        data = it,
+                        navigateToDetail = navigateToDetail
+                    )
                 }
             }
         }

--- a/presentation/src/main/java/com/mpersand/presentation/view/search/component/SearchResultItem.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/search/component/SearchResultItem.kt
@@ -1,6 +1,7 @@
 package com.mpersand.presentation.view.search.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,9 +23,14 @@ import com.mpersand.domain.model.equipment.response.EquipmentResponseModel
 import com.mpersand.presentation.R
 
 @Composable
-fun SearchResultItem(data: EquipmentResponseModel) {
+fun SearchResultItem(
+    data: EquipmentResponseModel,
+    navigateToDetail: (productNumber: String) -> Unit
+) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { navigateToDetail(data.productNumber) },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Image(

--- a/presentation/src/main/java/com/mpersand/presentation/view/search/navigation/SearchNavigation.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/search/navigation/SearchNavigation.kt
@@ -11,8 +11,14 @@ fun NavController.navigateToSearch() {
     this.navigate(searchRoute)
 }
 
-fun NavGraphBuilder.searchScreen(navigateToMain: () -> Unit) {
+fun NavGraphBuilder.searchScreen(
+    navigateToMain: () -> Unit,
+    navigateToDetail: (productNumber: String) -> Unit
+) {
     composable(searchRoute) {
-        SearchScreen(navigateToMain = navigateToMain)
+        SearchScreen(
+            navigateToMain = navigateToMain,
+            navigateToDetail = navigateToDetail
+        )
     }
 }


### PR DESCRIPTION
### 개요
- 검색 결과 리스트에서 detail로 이동하는 navigation 추가

### 작업내용
- search screen, detail screen 간의 navigation 생성, 적용
- profile 대여한 기자재 개수 얻어오는 로직 생성(profile screen은 refactoring에 가까움)

### 기타사항 (선택)
- profile 관련 변경사항을 따로 하기에는 귀찮아서 여기에 담았습니다. 이해 부탁드려요
